### PR TITLE
Method to support raw message delivery

### DIFF
--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -378,7 +378,72 @@ class AWSPubSubAdapter():
             logger.exception(
                 "Couldn't poll message from queue with URL=%s!", sqs_queue_url)
             raise error
+        
+    def poll_raw_message_from_queue(
+        self,
+        sqs_queue_url: str,
+        handler,
+        visibility_timeout: int = 15,
+        wait_time_seconds: int = 20,
+        message_attribute_names: list = ['All'],
+        max_number_of_messages: int = 10,
+        attribute_names: list = ['All']
+    ):
+        """
+            This method is used to poll raw message from the queue.
+            The Message response will look something like:
+            {
+                'MessageId': 'c6af9ac6-7b61-11e6-9a41-93e8deadbeef',
+                'ReceiptHandle': 'MessageReceiptHandle',
+                'MD5OfBody': '275a635e474a51e0c5a2d638b19ba19e',
+                'Body': 'Hello from SQS!',
+                'Attributes': {
+                    'SentTimestamp': '1477981389573'
+                },
+                'MessageAttributes': {},
+                'MD5OfMessageAttributes': '275a635e474a51e0c5a2d638b19ba19e'
+            }
+        """
+        try:
+            recieved_message = self.sqs_client.receive_message(
+                QueueUrl=sqs_queue_url,
+                MaxNumberOfMessages=max_number_of_messages,
+                VisibilityTimeout=visibility_timeout,
+                WaitTimeSeconds=wait_time_seconds,
+                MessageAttributeNames=message_attribute_names,
+                AttributeNames=attribute_names
+            )
 
+            if 'Messages' in recieved_message:
+                for message in recieved_message['Messages']:
+                    if not is_message_integrity_verified(message['Body'], message['MD5OfBody']):
+                        raise ValueError(
+                            "message corrupted, Message integrity verification failed!")
+                    message['Body'] = json.loads(message['Body'])
+                    message_attributes = message['MessageAttributes']
+                    if message_attributes and 'redis_key' in message_attributes:
+                        redis_key = message_attributes['redis_key']['Value']
+                        message_body = self.fetch_value_from_redis(redis_key)
+                        if message_body:
+                            message['Body'] = message_body
+                        else:
+                            logger.exception(
+                                "Couldn't find message body in redis with key=%s!", redis_key)
+                            continue
+                    processing_result = handler(message)
+                    if processing_result:
+                        self.sqs_client.delete_message(
+                            QueueUrl=sqs_queue_url,
+                            ReceiptHandle=message['ReceiptHandle']
+                        )
+            else:
+                logger.info("No messages in queue with URL=%s!", sqs_queue_url)
+            return recieved_message
+        except ClientError as error:
+            logger.exception(
+                "Couldn't poll message from queue with URL=%s!", sqs_queue_url)
+            raise error
+    
     def subscribe_to_topic(
         self,
         sns_topic_arn_list: list,

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -390,7 +390,7 @@ class AWSPubSubAdapter():
         attribute_names: list = ['All']
     ):
         """
-            This method is used to poll raw message from the queue.
+            This method is used to poll raw message from the queue when raw message delivery is enabled for a topic.
             The Message response will look something like:
             {
                 'MessageId': 'c6af9ac6-7b61-11e6-9a41-93e8deadbeef',


### PR DESCRIPTION
## **Description**
- Introduced a new method `poll_raw_message_from_queue` in the `AWSPubSubAdapter` class to support polling of raw messages from an SQS queue.
- The method includes verification of message integrity by comparing the message body with the provided MD5 hash.
- If a `redis_key` is present in the message attributes, the method attempts to fetch the message body from Redis.
- After successful processing by the provided handler, the message is deleted from the queue.

### Why?
- For the `revenue.realised` event we have raw message delivery enabled



___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Add Raw Message Polling Support to AWSPubSubAdapter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pubsublib/aws/main.py
<li>Added <code>poll_raw_message_from_queue</code> method to <code>AWSPubSubAdapter</code> class.<br> <li> Method handles polling of raw messages from an SQS queue with raw <br>message delivery enabled.<br> <li> Includes integrity check of the message body against its MD5 hash.<br> <li> Retrieves message body from Redis if a <code>redis_key</code> is provided in <br>message attributes.<br> <li> Deletes message from the queue after successful processing by the <br>handler.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Orange-Health/pubsublib-python/pull/4/files#diff-56539a907daab5c302d5dba6d26febdd9bcbf59402b181c867af44c3b3c0c838">+65/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details><summary><strong>🔍 Secrets Detected:</strong></summary><hr>
<table><tr><td><details><summary><strong>/src/pubsublib/aws/main.py</strong></summary><div><table><tr><th>Type</th><th>Line Number</th></tr><tr><td>Hex High Entropy String</td><td><a href='https://github.com/Orange-Health/pubsublib-python/blob/raw_message_Delivery//src/pubsublib/aws/main.py#L334' target='_blank'>334</a></td></tr></table></div></details></td></tr></table></details><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
