### PR TITLE
Add Gzip Compression/Decompression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "hatchling.build"
 name = "pubsublib"
 version = "0.1.18"
 authors = [
-  { name="Anant Chauhan", email="anant.chauhan@orangehealth.in"},
-  { name="Rajendra Talekar", email="talekar.r@gmail.com"}
+    {name = "Anant Chauhan", email = "anant.chauhan@orangehealth.in"},
+    {name = "Rajendra Talekar", email = "talekar.r@gmail.com"}
 ]
 description = "The Python Adaptation of the PubSubLib for Orange Health"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pubsublib"
-version = "0.1.17"
+version = "0.1.18"
 authors = [
-  { name="Saket Shrivastava", email="message.saket@gmail.com" },
+  { name="Anant Chauhan", email="anant.chauhan@orangehealth.in"},
   { name="Rajendra Talekar", email="talekar.r@gmail.com"}
 ]
 description = "The Python Adaptation of the PubSubLib for Orange Health"

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -3,6 +3,7 @@ import boto3
 from botocore.exceptions import ClientError
 import logging
 import boto3.session
+from typing import Tuple, Dict
 from pubsublib.aws.utils.helper import bind_attributes, validate_message_attributes, is_message_integrity_verified
 from pubsublib.common.codec import gzip_and_b64, b64_decode_and_gunzip_if
 from pubsublib.common.cache_adapter import CacheAdapter
@@ -149,7 +150,7 @@ class AWSPubSubAdapter():
                 attributes
             )
 
-    def __compress_and_flag(self, message: str, attributes: dict) -> tuple[str, dict]:
+    def __compress_and_flag(self, message: str, attributes: dict) -> Tuple[str, dict]:
         """gzip+base64 the message and set compress flag on attributes."""
         attributes = attributes or {}
         b64 = gzip_and_b64(message.encode("utf-8"))

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -372,31 +372,15 @@ class AWSPubSubAdapter():
                     # Decode/decompress if needed (SNS envelope)
                     try:
                         sqs_attrs = message.get('MessageAttributes', {}) or {}
-                        compressed = False
-                        
-                        # Check for flag: compress="true"
                         compress_attr = sqs_attrs.get('compress', {})
-                        if str(compress_attr.get('StringValue', '')).lower() == 'true':
-                            compressed = True
-                        
-                        # Check for citadel/hedwig flag: content_encoding="gzip"
+                        compressed = str(compress_attr.get(
+                            'StringValue', '')).lower() == 'true'
                         if not compressed:
-                            content_encoding_attr = sqs_attrs.get('content_encoding', {})
-                            if str(content_encoding_attr.get('StringValue', '')).lower() == 'gzip':
-                                compressed = True
-                        
-                        # Check in SNS envelope MessageAttributes
-                        if not compressed:
-                            body_attrs = message['Body'].get('MessageAttributes', {}) or {}
-                            # Check for compress flag
+                            body_attrs = message['Body'].get(
+                                'MessageAttributes', {}) or {}
                             if 'compress' in body_attrs:
-                                if str(body_attrs.get('compress', {}).get('Value', '')).lower() == 'true':
-                                    compressed = True
-                            # Check for content_encoding flag
-                            if not compressed and 'content_encoding' in body_attrs:
-                                if str(body_attrs.get('content_encoding', {}).get('Value', '')).lower() == 'gzip':
-                                    compressed = True
-                        
+                                compressed = str(body_attrs.get('compress', {}).get(
+                                    'Value', '')).lower() == 'true'
                         if compressed and isinstance(message['Body'].get('Message'), str):
                             decoded = b64_decode_and_gunzip_if(
                                 message['Body']['Message'], True)
@@ -477,17 +461,8 @@ class AWSPubSubAdapter():
                             continue
 
                     # Decompress if flagged
-                    compressed = False
-                    
-                    # Check for flag: compress="true"
-                    if str(msg_attrs.get('compress', {}).get('StringValue', '')).lower() == 'true':
-                        compressed = True
-                    
-                    # Check for old citadel/hedwig flag: content_encoding="gzip"
-                    if not compressed:
-                        if str(msg_attrs.get('content_encoding', {}).get('StringValue', '')).lower() == 'gzip':
-                            compressed = True
-                    
+                    compressed = str(msg_attrs.get('compress', {}).get(
+                        'StringValue', '')).lower() == 'true'
                     try:
                         if compressed and isinstance(body_str, str):
                             decoded = b64_decode_and_gunzip_if(body_str, True)

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -3,7 +3,8 @@ import boto3
 from botocore.exceptions import ClientError
 import logging
 import boto3.session
-from pubsublib.aws.utils.helper import bind_attributes, is_large_message, validate_message_attributes, is_message_integrity_verified
+from pubsublib.aws.utils.helper import bind_attributes, validate_message_attributes, is_message_integrity_verified
+from pubsublib.common.codec import gzip_and_b64
 from pubsublib.common.cache_adapter import CacheAdapter
 import uuid
 
@@ -148,6 +149,13 @@ class AWSPubSubAdapter():
                 attributes
             )
 
+    def __compress_and_flag(self, message: str, attributes: dict) -> tuple[str, dict]:
+        """gzip+base64 the message and set compress flag on attributes."""
+        attributes = attributes or {}
+        b64 = gzip_and_b64(message.encode("utf-8"), level=-1)
+        attributes["compress"] = "true"
+        return b64, attributes
+
     def __publish_message_standard_queue(
         self,
         topic_arn: str,
@@ -166,11 +174,8 @@ class AWSPubSubAdapter():
         :return: The ID of the message.
         """
         try:
-            if is_large_message(message):
-                # body is larger than 64kB. Best to put it in redis with expiry time of 10 days
-                redis_key = uuid.uuid4()
-                attributes["redis_key"] = redis_key
-                self.cache_adapter.set(redis_key, message, 10*24*60)
+            # (gzip + base64)
+            message, attributes = self.__compress_and_flag(message, attributes)
 
             if validate_message_attributes(attributes):
                 message_attributes = bind_attributes(attributes)
@@ -195,41 +200,39 @@ class AWSPubSubAdapter():
         message_deduplication_id: str,
         attributes: dict
     ):
-        """
-        Publishes a message to a FIFO topic. The message_group_id and message_deduplication_id
-        are used to ensure that the message is processed in the correct order and that
-        duplicate messages are not sent.
+    """
+    Publishes a message to a FIFO topic. The message_group_id and message_deduplication_id
+    are used to ensure that the message is processed in the correct order and that
+    duplicate messages are not sent.
 
-        :param topic: The topic to publish to.
-        :param message: The message to publish.
-        :param message_group_id: The message group ID.
-        :param message_deduplication_id: The message deduplication ID.
-        :param attributes: The key-value attributes to attach to the message. Values
-                           must be either `str` or `bytes`.
-        :return: The ID of the message.
-        """
-        try:
-            if is_large_message(message):
-                # body is larger than 200kB. Best to put it in redis with expiry time of 10 days
-                redis_key = uuid.uuid4()
-                attributes["redis_key"] = redis_key
-                self.cache_adapter.set(redis_key, message, 10*24*60)
+    :param topic: The topic to publish to.
+    :param message: The message to publish.
+    :param message_group_id: The message group ID.
+    :param message_deduplication_id: The message deduplication ID.
+    :param attributes: The key-value attributes to attach to the message. Values
+                       must be either `str` or `bytes`.
+    :return: The ID of the message.
+    """
+    try:
+        # (gzip + base64)
+        message, attributes = self.__compress_and_flag(message, attributes)
 
-            if validate_message_attributes(attributes):
-                message_attributes = bind_attributes(attributes)
-                response = self.sns_client.publish(
-                    TopicArn=topic_arn,
-                    Message=message,
-                    MessageGroupId=message_group_id,
-                    MessageDeduplicationId=message_deduplication_id,
-                    MessageAttributes=message_attributes
-                )
-                message_id = response["MessageId"]
-        except ClientError:
-            logger.exception(
-                "Couldn't publish message to FIFO topic %s.", topic_arn)
-        else:
-            return message_id
+        if validate_message_attributes(attributes):
+            message_attributes = bind_attributes(attributes)
+            response = self.sns_client.publish(
+                TopicArn=topic_arn,
+                Message=message,
+                MessageGroupId=message_group_id,
+                MessageDeduplicationId=message_deduplication_id,
+                MessageAttributes=message_attributes
+            )
+            message_id = response["MessageId"]
+    except ClientError:
+        logger.exception(
+            "Couldn't publish message to FIFO topic %s.", topic_arn)
+        return None
+    else:
+        return message_id
 
     def create_queue(
         self,

--- a/src/pubsublib/common/codec.py
+++ b/src/pubsublib/common/codec.py
@@ -1,0 +1,41 @@
+import base64
+import gzip
+from io import BytesIO
+
+
+def gzip_compress(data: bytes, level: int = 9) -> bytes:
+    """compresses the given data"""
+    buf = BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode='wb', compresslevel=level) as gz:
+        gz.write(data)
+    return buf.getvalue()
+
+
+def gzip_decompress(data: bytes) -> bytes:
+    """decompresses gzip-compressed bytes"""
+    with gzip.GzipFile(fileobj=BytesIO(data), mode='rb') as gz:
+        return gz.read()
+
+
+def b64_encode(data: bytes) -> str:
+    """returns base64-encoded string of data"""
+    return base64.b64encode(data).decode('ascii')
+
+
+def b64_decode(s: str) -> bytes:
+    """decodes base64 string to bytes"""
+    return base64.b64decode(s)
+
+
+def gzip_and_b64(data: bytes, level: int = 9) -> str:
+    """gzip + base64. returns b64 string"""
+    to_encode = gzip_compress(data, level=level)
+    return b64_encode(to_encode)
+
+
+def b64_decode_and_gunzip_if(b64s: str, compressed: bool) -> bytes:
+    """base64 decode + gunzip if compressed"""
+    decoded = b64_decode(b64s)
+    if compressed:
+        return gzip_decompress(decoded)
+    return decoded

--- a/src/pubsublib/common/codec.py
+++ b/src/pubsublib/common/codec.py
@@ -1,20 +1,45 @@
 import base64
 import gzip
+import logging
 from io import BytesIO
+
+logger = logging.getLogger(__name__)
 
 
 def gzip_compress(data: bytes, level: int = 9) -> bytes:
     """compresses the given data"""
+    in_size = len(data) if data is not None else 0
+    logger.info("gzip_compress: start input_bytes=%d level=%d", in_size, level)
     buf = BytesIO()
     with gzip.GzipFile(fileobj=buf, mode='wb', compresslevel=level) as gz:
         gz.write(data)
-    return buf.getvalue()
+    out = buf.getvalue()
+    out_size = len(out)
+    ratio_pct = (1.0 - (out_size / in_size)) * 100.0 if in_size else 0.0
+    logger.info(
+        "gzip_compress: done input_bytes=%d output_bytes=%d ratio=%.2f%% level=%d",
+        in_size,
+        out_size,
+        ratio_pct,
+        level,
+    )
+    return out
 
 
 def gzip_decompress(data: bytes) -> bytes:
     """decompresses gzip-compressed bytes"""
-    with gzip.GzipFile(fileobj=BytesIO(data), mode='rb') as gz:
-        return gz.read()
+    in_size = len(data) if data is not None else 0
+    logger.info("gzip_decompress: start input_bytes=%d", in_size)
+    try:
+        with gzip.GzipFile(fileobj=BytesIO(data), mode='rb') as gz:
+            out = gz.read()
+    except Exception:
+        logger.exception("gzip_decompress: failed input_bytes=%d", in_size)
+        raise
+    out_size = len(out)
+    logger.info(
+        "gzip_decompress: done input_bytes=%d output_bytes=%d", in_size, out_size)
+    return out
 
 
 def b64_encode(data: bytes) -> str:
@@ -29,13 +54,40 @@ def b64_decode(s: str) -> bytes:
 
 def gzip_and_b64(data: bytes, level: int = 9) -> str:
     """gzip + base64. returns b64 string"""
+    in_size = len(data) if data is not None else 0
+    logger.info("gzip_and_b64: start input_bytes=%d level=%d", in_size, level)
     to_encode = gzip_compress(data, level=level)
-    return b64_encode(to_encode)
+    gz_size = len(to_encode)
+    b64s = b64_encode(to_encode)
+    logger.info(
+        "gzip_and_b64: done input_bytes=%d gz_bytes=%d b64_len=%d level=%d",
+        in_size,
+        gz_size,
+        len(b64s),
+        level,
+    )
+    return b64s
 
 
 def b64_decode_and_gunzip_if(b64s: str, compressed: bool) -> bytes:
     """base64 decode + gunzip if compressed"""
+    logger.info(
+        "b64_decode_and_gunzip_if: start compressed=%s b64_len=%d",
+        compressed,
+        len(b64s) if b64s is not None else 0,
+    )
     decoded = b64_decode(b64s)
     if compressed:
-        return gzip_decompress(decoded)
+        out = gzip_decompress(decoded)
+        logger.info(
+            "b64_decode_and_gunzip_if: done compressed=%s decoded_bytes=%d",
+            compressed,
+            len(out),
+        )
+        return out
+    logger.info(
+        "b64_decode_and_gunzip_if: done compressed=%s decoded_bytes=%d",
+        compressed,
+        len(decoded),
+    )
     return decoded


### PR DESCRIPTION
This PR introduces gzip compression and base64 encoding functionality to the pubsub library. The main purpose is to compress messages before publishing them to AWS topics, replacing the previous large message handling strategy that stored oversized messages in Redis.

- Added compression/decompression utilities with gzip and base64 encoding functions
- Replaced large message Redis storage with automatic compression for all messages
- Updated both standard and FIFO queue publishing methods to use compression