### PR TITLE
Feat: Introduce forward compatibility to the library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pubsublib"
-version = "0.1.18"
+version = "0.1.19"
 authors = [
     {name = "Anant Chauhan", email = "anant.chauhan@orangehealth.in"},
     {name = "Rajendra Talekar", email = "talekar.r@gmail.com"}

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -3,7 +3,7 @@ import boto3
 from botocore.exceptions import ClientError
 import logging
 import boto3.session
-from typing import Tuple, Dict
+from typing import Tuple, Dict, Optional
 from pubsublib.aws.utils.helper import bind_attributes, validate_message_attributes, is_message_integrity_verified, is_large_message
 from pubsublib.common.codec import gzip_and_b64, b64_decode_and_gunzip_if
 from pubsublib.common.cache_adapter import CacheAdapter
@@ -23,7 +23,7 @@ class AWSPubSubAdapter():
         sns_endpoint_url: str = None,
         sqs_endpoint_url: str = None,
         max_connections: int = 10,
-        compress_enabled: bool | None = None,
+        compress_enabled: Optional[bool] = None,
     ):
         self.my_session = boto3.session.Session(
             region_name=aws_region,

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -4,10 +4,11 @@ from botocore.exceptions import ClientError
 import logging
 import boto3.session
 from typing import Tuple, Dict
-from pubsublib.aws.utils.helper import bind_attributes, validate_message_attributes, is_message_integrity_verified
+from pubsublib.aws.utils.helper import bind_attributes, validate_message_attributes, is_message_integrity_verified, is_large_message
 from pubsublib.common.codec import gzip_and_b64, b64_decode_and_gunzip_if
 from pubsublib.common.cache_adapter import CacheAdapter
 import uuid
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,8 @@ class AWSPubSubAdapter():
         redis_location: str,
         sns_endpoint_url: str = None,
         sqs_endpoint_url: str = None,
-        max_connections: int = 10
+        max_connections: int = 10,
+        compress_enabled: bool | None = None,
     ):
         self.my_session = boto3.session.Session(
             region_name=aws_region,
@@ -39,6 +41,14 @@ class AWSPubSubAdapter():
         else:
             self.sqs_client = self.my_session.client("sqs")
         self.cache_adapter = CacheAdapter(redis_location, max_connections)
+        if compress_enabled is None:
+            envv = os.getenv("PUBSUBLIB_COMPRESSION_ENABLED", "")
+            self.compress_enabled = str(envv).lower() in ("true", "1", "yes")
+        else:
+            self.compress_enabled = bool(compress_enabled)
+
+    def set_compression_enabled(self, enabled: bool):
+        self.compress_enabled = bool(enabled)
 
     def create_topic(
         self,
@@ -151,7 +161,9 @@ class AWSPubSubAdapter():
             )
 
     def __compress_and_flag(self, message: str, attributes: dict) -> Tuple[str, dict]:
-        """gzip+base64 the message and set compress flag on attributes."""
+        """gzip+base64 the message and set compress flag on attributes if compression enabled."""
+        if not getattr(self, "compress_enabled", True):
+            return message, attributes or {}
         attributes = attributes or {}
         b64 = gzip_and_b64(message.encode("utf-8"))
         attributes["compress"] = "true"
@@ -175,8 +187,15 @@ class AWSPubSubAdapter():
         :return: The ID of the message.
         """
         try:
-            # (gzip + base64)
+            # (gzip + base64) if compression enabled
             message, attributes = self.__compress_and_flag(message, attributes)
+
+            # offload large bodies to Redis (200kb limit)
+            if is_large_message(message):
+                attributes = attributes or {}
+                redis_key = str(uuid.uuid4())
+                attributes["redis_key"] = redis_key
+                self.cache_adapter.set(redis_key, message, 10*24*60)
 
             if validate_message_attributes(attributes):
                 message_attributes = bind_attributes(attributes)
@@ -215,8 +234,15 @@ class AWSPubSubAdapter():
         :return: The ID of the message.
         """
         try:
-            # (gzip + base64)
+            # (gzip + base64) if compression enabled
             message, attributes = self.__compress_and_flag(message, attributes)
+
+            # offload large bodies to Redis (200kb limit)
+            if is_large_message(message):
+                attributes = attributes or {}
+                redis_key = str(uuid.uuid4())
+                attributes["redis_key"] = redis_key
+                self.cache_adapter.set(redis_key, message, 10*24*60)
 
             if validate_message_attributes(attributes):
                 message_attributes = bind_attributes(attributes)


### PR DESCRIPTION
## **User description**
This pull request adds support for optional message compression and handling of large messages in the AWS pub/sub library. The main changes introduce a configurable compression option, offload large message bodies to Redis, and improve message attribute handling.

**Compression feature:**

* Added a `compress_enabled` parameter to the class initializer in `main.py`, which can be set via constructor or environment variable `PUBSUBLIB_COMPRESSION_ENABLED`. Also added a `set_compression_enabled` method to update this setting at runtime. 

* Updated the `__compress_and_flag` method to only compress messages if compression is enabled.

**Large message handling:**

* In both `__publish_message_standard_queue` and `__publish_message_fifo_queue`, added logic to detect large messages (using `is_large_message`) and offload their bodies to Redis, storing a reference key in message attributes. 

**Imports and utility functions:**

* Imported the new `is_large_message` utility function to support large message detection.


___

## **CodeAnt-AI Description**
**Support optional message compression and Redis offload for large messages**

### What Changed
- Messages can be gzip+base64 compressed before being published; when compression is enabled the published message includes a "compress" attribute.
- Message bodies that exceed the size threshold are stored in Redis and the published message includes a "redis_key" attribute referencing the stored body, preventing oversized SNS/SQS payloads.
- The compression toggle can be set via the constructor, the PUBSUBLIB_COMPRESSION_ENABLED environment variable, or at runtime using a setter; compression and Redis offload apply to both standard and FIFO topic publishing.

### Impact
`✅ Fewer publish failures for oversized messages`
`✅ Smaller SNS/SQS payloads when compression is enabled`
`✅ Toggle compression without changing publish call sites`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
