### PR TITLE
Support for IRSA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repo
-* @SaketOH @architv @rdvs @rdhoot-oh @raj-nt  
+* @architv @rdvs @raj-nt  

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pubsub_adapter = AWSPubSubAdapter(
 
 #### Using AWS IAM Roles for Service Accounts 
 
-Pass `aws_region`, `aws_access_key_id` and `aws_secret_access_key` as empty strings to intialize AWS SDK without credentials, effectively falling back to Service Accounts
+When using IAM Roles for Service Accounts (IRSA), pass `aws_access_key_id` and `aws_secret_access_key` as empty strings so that the AWS SDK uses its default credential provider chain (which will pick up the service account role). You should still provide a valid `aws_region` here, or ensure that `AWS_REGION` or `AWS_DEFAULT_REGION` is set in the environment or shared AWS config when omitting it.
 
 [Steps to Publish Package](https://github.com/Orange-Health/pubsublib-python/wiki/PyPI-%7C-Publish-Package#steps-to-publish-the-pubsublib-package-on-pypi)
 

--- a/README.md
+++ b/README.md
@@ -28,5 +28,9 @@ pubsub_adapter = AWSPubSubAdapter(
 )
 ```
 
+#### Using AWS IAM Roles for Service Accounts 
+
+Pass `aws_region`, `aws_access_key_id` and `aws_secret_access_key` as empty strings to intialize AWS SDK without credentials, effectively falling back to Service Accounts
+
 [Steps to Publish Package](https://github.com/Orange-Health/pubsublib-python/wiki/PyPI-%7C-Publish-Package#steps-to-publish-the-pubsublib-package-on-pypi)
 

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -25,11 +25,14 @@ class AWSPubSubAdapter():
         max_connections: int = 10,
         compress_enabled: Optional[bool] = None,
     ):
-        self.my_session = boto3.session.Session(
-            region_name=aws_region,
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key
-        )
+        if aws_access_key_id and aws_secret_access_key:
+            self.my_session = boto3.session.Session(
+                region_name=aws_region,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key
+            )
+        else:
+            self.my_session = boto3.session.Session()
         if sns_endpoint_url != None:
             self.sns_client = self.my_session.client(
                 "sns", endpoint_url=sns_endpoint_url)


### PR DESCRIPTION
## **User description**
This pull request introduces support for using AWS IAM Roles for Service Accounts by allowing the AWS SDK to initialize without explicit credentials, and updates documentation to reflect this new usage pattern. Additionally, there is a minor update to the repository's code ownership.

**AWS IAM Roles for Service Accounts support:**

* Updated `src/pubsublib/aws/main.py` to initialize the AWS SDK session without credentials when `aws_access_key_id` and `aws_secret_access_key` are not provided, enabling the use of IAM Roles for Service Accounts.
* Updated `README.md` to document how to use AWS IAM Roles for Service Accounts by passing empty strings for AWS credentials.

**Repository ownership:**

* Removed `@SaketOH` from the default owners in `.github/CODEOWNERS`.


___

## **CodeAnt-AI Description**
**Allow AWS SDK to initialize without credentials to support Kubernetes IRSA**

### What Changed
- When no AWS access key and secret are provided, the adapter now creates the AWS session without explicit credentials so the process can rely on pod service-account roles (IRSA) or other ambient credentials.
- README updated with instructions to pass empty strings for AWS credentials to enable the IRSA behavior.
- Removed a username from the repository default CODEOWNERS list.

### Impact
`✅ Works with Kubernetes IRSA for AWS access`
`✅ Fewer credential misconfiguration errors when running in-cluster`
`✅ Clearer repository ownership`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
