### PR TITLE
Add optional SQS SSE-SQS support at adapter level

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,21 @@ pubsub_adapter = AWSPubSubAdapter(
 
 When using IAM Roles for Service Accounts (IRSA), pass `aws_access_key_id` and `aws_secret_access_key` as empty strings so that the AWS SDK uses its default credential provider chain (which will pick up the service account role). You should still provide a valid `aws_region` here, or ensure that `AWS_REGION` or `AWS_DEFAULT_REGION` is set in the environment or shared AWS config when omitting it.
 
+#### SQS server-side encryption (SSE-SQS)
+
+Optional adapter setting — **off by default**, fully backward compatible. Existing `AWSPubSubAdapter(...)` calls work unchanged.
+
+```python
+pubsub_adapter = AWSPubSubAdapter(
+    aws_region='ap-south-1',
+    aws_access_key_id='',
+    aws_secret_access_key='',
+    redis_location='redis://localhost:6379/0',
+    sqs_managed_sse_enabled=True,  # optional; omit or pass False to keep current behaviour
+)
+```
+
+All `create_queue` calls on that adapter then set `SqsManagedSseEnabled=true`. If the queue already exists, SSE is applied via `SetQueueAttributes`. You can also toggle at runtime with `set_sqs_managed_sse_enabled(True)`.
+
 [Steps to Publish Package](https://github.com/Orange-Health/pubsublib-python/wiki/PyPI-%7C-Publish-Package#steps-to-publish-the-pubsublib-package-on-pypi)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pubsublib"
-version = "0.1.21"
+version = "0.1.22"
 authors = [
     {name = "Anant Chauhan", email = "anant.chauhan@orangehealth.in"},
     {name = "Rajendra Talekar", email = "talekar.r@gmail.com"}

--- a/src/pubsublib/aws/main.py
+++ b/src/pubsublib/aws/main.py
@@ -24,6 +24,7 @@ class AWSPubSubAdapter():
         sqs_endpoint_url: str = None,
         max_connections: int = 10,
         compress_enabled: Optional[bool] = None,
+        sqs_managed_sse_enabled: Optional[bool] = None,
     ):
         if aws_access_key_id and aws_secret_access_key:
             self.my_session = boto3.session.Session(
@@ -49,9 +50,56 @@ class AWSPubSubAdapter():
             self.compress_enabled = str(envv).lower() in ("true", "1", "yes")
         else:
             self.compress_enabled = bool(compress_enabled)
+        if sqs_managed_sse_enabled is None:
+            self.sqs_managed_sse_enabled = False
+        else:
+            self.sqs_managed_sse_enabled = bool(sqs_managed_sse_enabled)
 
     def set_compression_enabled(self, enabled: bool):
         self.compress_enabled = bool(enabled)
+
+    def set_sqs_managed_sse_enabled(self, enabled: bool):
+        self.sqs_managed_sse_enabled = bool(enabled)
+
+    def _build_queue_create_attributes(
+        self,
+        *,
+        visiblity_timeout: int,
+        message_retention_period: int,
+        sqs_managed_sse_enabled: bool,
+        is_fifo: bool = False,
+        content_based_deduplication: bool = False,
+    ) -> Dict[str, str]:
+        attributes = {
+            "VisibilityTimeout": str(visiblity_timeout),
+            "MessageRetentionPeriod": str(message_retention_period),
+        }
+        if is_fifo:
+            attributes["FifoQueue"] = "true"
+            attributes["ContentBasedDeduplication"] = str(content_based_deduplication).lower()
+        if sqs_managed_sse_enabled:
+            attributes["SqsManagedSseEnabled"] = "true"
+        return attributes
+
+    def _enforce_sqs_managed_sse(self, queue_name: str) -> None:
+        try:
+            queue_url = self.sqs_client.get_queue_url(QueueName=queue_name)["QueueUrl"]
+        except ClientError:
+            logger.exception(
+                "Couldn't fetch queue URL to enforce SSE for queue %s.", queue_name
+            )
+            return
+
+        try:
+            self.sqs_client.set_queue_attributes(
+                QueueUrl=queue_url,
+                Attributes={"SqsManagedSseEnabled": "true"},
+            )
+            logger.info("Enforced SSE on existing queue %s", queue_name)
+        except ClientError:
+            logger.exception(
+                "Couldn't enforce SSE on existing queue %s.", queue_name
+            )
 
     def create_topic(
         self,
@@ -280,16 +328,26 @@ class AWSPubSubAdapter():
         :return: The newly created queue.
         """
         if is_fifo:
-            return self.__create_fifo_queue(name, visiblity_timeout, message_retention_period, content_based_deduplication, tags)
-        else:
-            return self.__create_standard_queue(name, visiblity_timeout, message_retention_period, tags)
+            return self.__create_fifo_queue(
+                name,
+                visiblity_timeout,
+                message_retention_period,
+                content_based_deduplication,
+                tags,
+            )
+        return self.__create_standard_queue(
+            name,
+            visiblity_timeout,
+            message_retention_period,
+            tags,
+        )
 
     def __create_standard_queue(
         self,
         name: str,
         visiblity_timeout: int = 30,
         message_retention_period: int = 345600,
-        tags: dict = {}
+        tags: dict = {},
     ):
         """
         Creates a queue.
@@ -301,14 +359,19 @@ class AWSPubSubAdapter():
         try:
             queue = self.sqs_client.create_queue(
                 QueueName=name,
-                Attributes={
-                    "VisibilityTimeout": str(visiblity_timeout),
-                    "MessageRetentionPeriod": str(message_retention_period)
-                },
+                Attributes=self._build_queue_create_attributes(
+                    visiblity_timeout=visiblity_timeout,
+                    message_retention_period=message_retention_period,
+                    sqs_managed_sse_enabled=self.sqs_managed_sse_enabled,
+                ),
                 tags=tags
             )
             logger.info("Created queue %s ", name)
-        except ClientError:
+        except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            if self.sqs_managed_sse_enabled and error_code in ("QueueNameExists", "QueueAlreadyExists"):
+                self._enforce_sqs_managed_sse(name)
+                return self.sqs_client.get_queue_url(QueueName=name)
             logger.exception("Couldn't create queue %s.", name)
             raise
         else:
@@ -320,7 +383,7 @@ class AWSPubSubAdapter():
         visiblity_timeout: int = 30,
         message_retention_period: int = 345600,  # 4days
         content_based_deduplication: bool = True,
-        tags: dict = {}
+        tags: dict = {},
     ):
         """
         Creates a FIFO queue.
@@ -332,12 +395,13 @@ class AWSPubSubAdapter():
             if name.endswith(".fifo"):
                 queue = self.sqs_client.create_queue(
                     QueueName=name,
-                    Attributes={
-                        "FifoQueue": "true",
-                        "VisibilityTimeout": str(visiblity_timeout),
-                        "MessageRetentionPeriod": str(message_retention_period),
-                        "ContentBasedDeduplication": str(content_based_deduplication).lower()
-                    },
+                    Attributes=self._build_queue_create_attributes(
+                        visiblity_timeout=visiblity_timeout,
+                        message_retention_period=message_retention_period,
+                        sqs_managed_sse_enabled=self.sqs_managed_sse_enabled,
+                        is_fifo=True,
+                        content_based_deduplication=content_based_deduplication,
+                    ),
                     tags=tags
                 )
                 logger.info("Created FIFO queue with name=%s.", name)
@@ -346,6 +410,10 @@ class AWSPubSubAdapter():
                 logger.error("FIFO Queue name must end with .fifo!")
                 return None
         except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            if self.sqs_managed_sse_enabled and error_code in ("QueueNameExists", "QueueAlreadyExists"):
+                self._enforce_sqs_managed_sse(name)
+                return self.sqs_client.get_queue_url(QueueName=name)
             logger.exception("Couldn't create FIFO queue with name=%s!", name)
             raise error
 


### PR DESCRIPTION
## **User description**
## Summary

- Add optional `sqs_managed_sse_enabled` on `AWSPubSubAdapter` (defaults to **False** — fully backward compatible)
- When enabled, `create_queue` sets `SqsManagedSseEnabled=true` in `CreateQueue` attributes for standard and FIFO queues
- If the queue already exists, SSE is applied via `SetQueueAttributes`
- Add `set_sqs_managed_sse_enabled()` for runtime toggle
- Bump version to `0.1.22`

## Problem

Python services (e.g. health-api) use pubsublib `create_queue`, which did not set SSE on SQS queues. OMS/Citadel handle this in app-level sqs init; Python pubsub consumers had no equivalent.

## Root Cause

`create_queue` only set `VisibilityTimeout` and `MessageRetentionPeriod` — no `SqsManagedSseEnabled` attribute.

## Changes

- `src/pubsublib/aws/main.py` — adapter flag, attribute builder, enforce on existing queues
- `pyproject.toml` — version `0.1.22`
- `README.md` — usage docs

## Backward compatibility

Existing callers unchanged — omit `sqs_managed_sse_enabled` or pass `False`. `create_queue` signature is unchanged.

## Usage (health-api / other consumers)

```python
pubsub_adapter = AWSPubSubAdapter(
    ...,
    sqs_managed_sse_enabled=True,
)
pubsub_adapter.create_queue(name='my-consumer.fifo', is_fifo=True)
```

## Test plan

- [ ] Verify existing adapter construction without new param behaves as before
- [ ] With `sqs_managed_sse_enabled=True`, new queue shows SSE-SQS in AWS console
- [ ] With `sqs_managed_sse_enabled=True`, existing unencrypted queue gets SSE after create_queue call
- [ ] Publish `0.1.22` to PyPI after merge

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add optional SQS server-side encryption when creating queues**

### What Changed
- Queue creation can now turn on SQS-managed server-side encryption from the adapter, without changing existing callers
- New queues created with this setting enabled include encryption automatically for both standard and FIFO queues
- If a queue already exists, the adapter now applies encryption to that queue instead of leaving it unchanged
- The adapter can also be switched on or off at runtime, and the README now shows how to use the setting

### Impact
`✅ Encrypted SQS queues from app setup`
`✅ Fewer manual steps for existing queues`
`✅ No change for current users who keep the setting off`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
